### PR TITLE
document opentofu support

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ In addition to the regular `nix` module inputs and those defined by calls to the
 
 _NOTE:_ Both `outputs` and `resources` will be `null` when a `teraflops` module is evaluated for the purpose of generating `terraform` code in order to avoid recursion.
 
+## `opentofu` support
+
+`teraflops` provides support for `opentofu` via `nixpkgs`. See [examples/opentofu](examples/opentofu/flake.nix) for a working example.
+
 ## Comparison
 
 ### colmena

--- a/examples/opentofu/flake.nix
+++ b/examples/opentofu/flake.nix
@@ -1,0 +1,65 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    teraflops.url = "github:aanderse/teraflops";
+    teraflops.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { nixpkgs, teraflops, ... }:
+    let
+      system = "x86_64-linux";
+
+      pkgs = nixpkgs.legacyPackages.${system};
+
+      # NOTE: this is a workaround while opentofu support is being improved in nixpkgs... see https://github.com/NixOS/nixpkgs/issues/283015 for details 
+      tofuProvider = provider:
+        provider.override (oldArgs: {
+          provider-source-address =
+            pkgs.lib.replaceStrings
+              [ "https://registry.terraform.io/providers" ]
+              [ "registry.opentofu.org" ]
+              oldArgs.homepage;
+        });
+    in
+    {
+      devShells.${system}.default = with pkgs;
+        mkShell {
+          pname = "teraflops-digitalocean";
+
+          packages = [
+            colmena
+            jq
+            (opentofu.withPlugins (p: map tofuProvider [ p.digitalocean p.ssh p.tls ]))
+            teraflops.packages.${system}.default
+          ];
+        };
+    } // {
+      teraflops = {
+        imports = [ teraflops.modules.digitalocean ];
+
+        meta = {
+          nixpkgs = nixpkgs.legacyPackages.${system};
+        };
+
+        defaults = { ... }: {
+          deployment.targetEnv = "digitalocean";
+          deployment.digitalocean = {
+            region = "fra1";
+            size = "s-1vcpu-1gb";
+          };
+
+          system.stateVersion = "24.05";
+        };
+
+        machine = { pkgs, ... }: {
+          fileSystems."/storage" = {
+            fsType = "ext4";
+            label = "storage";
+            digitalocean.size = 10;
+          };
+
+          environment.systemPackages = [ pkgs.hello ];
+        };
+      };
+    };
+}

--- a/teraflops/main.py
+++ b/teraflops/main.py
@@ -541,7 +541,7 @@ class App:
 
     self.generate_main_tf_json(refresh=False, rewrite_args=True)
 
-    subprocess.run(['terraform', 'apply', '-target=terraform_data.teraflops-arguments', '-auto-approve'], stdout=subprocess.DEVNULL, check=True)
+    subprocess.run([self.terraform, 'apply', '-target=terraform_data.teraflops-arguments', '-auto-approve'], stdout=subprocess.DEVNULL, check=True)
 
   def show_args(self, args):
     if args.json:


### PR DESCRIPTION
- fixes issue mentioned [here](https://github.com/aanderse/teraflops/issues/7#issuecomment-2169452321) entirely negating the need for a `terraform` binary when `tofu` binary is available
- explicitly mentions `opentofu` in `README.md`
- provides concrete example on using `opentofu` and links to relevant upstream `nixpkgs` issue

ping @KiaraGrouwstra @AkechiShiro for review and any additional input/suggestions they have :bowing_man: