### PR TITLE
remove generated terraform file (main.tf.json) once it is done being …

### DIFF
--- a/teraflops/main.py
+++ b/teraflops/main.py
@@ -123,7 +123,8 @@ class App:
       process = subprocess.run([self.terraform, 'show', '-json'], stdout=subprocess.PIPE, check=True)
       data = json.loads(process.stdout)
 
-      os.remove('main.tf.json')
+      with contextlib.suppress(FileNotFoundError):
+        os.remove('main.tf.json')
     else:
       with tempfile.NamedTemporaryFile(mode='w', dir=os.getcwd(), prefix='teraflops', suffix='.tf.json') as fp:
         # generate a minimal .tf.json file which can be used to run 'terraform show -json'
@@ -284,6 +285,9 @@ class App:
 
     process = subprocess.run([self.terraform, 'output', '-json', 'teraflops'], capture_output=True)
 
+    with contextlib.suppress(FileNotFoundError):
+      os.remove('main.tf.json')
+
     try:
       output = json.loads(process.stdout)
     except:
@@ -335,6 +339,9 @@ class App:
     # if nix_version.at_least(2, 10):
     #   repl_cmd.arg("--file");
     cmd += [self.generate_repl_nix()]
+
+    with contextlib.suppress(FileNotFoundError):
+      os.remove('main.tf.json')
 
     subprocess.run(cmd, check=True)
 


### PR DESCRIPTION
…used

scenario: consider you have 2 shells open to your `teraflops` project - in one shell you are in a `teraflops repl` session, and the other you wish to run some deployment commands

currently `teraflops` does not cleanup the generated `main.tf.json` file until the program exits so you will run into a conflict between the two shells above

---

generated `main.tf.json` file is only needed briefly in most cases so we can remove it as soon as it is no longer required instead of waiting until `teraflops` invocations are complete